### PR TITLE
Make gem automatically enable active_support.report_deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Then in `config/application.rb`:
                   repo_environment_id: ENV['INFIELD_REPO_ENVIRONMENT_ID'])
     end
 
+Only call `Infield.run` in environments that you want deprecation warnings to print for, since it will bypass configurations such as `config.active_support.report_deprecations = false`
+and `config.active_support.deprecation = :silence`
+
 ## Configuration options
 
 The infield gem batches requests and sends them asyncronously. You can configure the following options to `Infield.run` (defaults shown here):

--- a/lib/infield/rails.rb
+++ b/lib/infield/rails.rb
@@ -4,6 +4,9 @@ module Infield
   class Railtie < Rails::Railtie
     initializer 'infield.enable_report_deprecations', before: 'active_support.deprecation_behavior' do |app|
       app.config.active_support.report_deprecations = true
+      if defined?(ActiveSupport::Deprecation.silenced)
+        ActiveSupport::Deprecation.silenced = false
+      end
     end
 
     initializer 'infield.deprecation_warnings', after: 'active_support.deprecation_behavior' do |app|
@@ -11,7 +14,7 @@ module Infield
         Infield::DeprecationWarning.log(message, callstack: callstack, validated: true)
       end
 
-      # Rails >= 7.0 makes it so that there are named deprecators that can have their own behavior
+      # Rails >= 7.1 makes it so that there are named deprecators that can have their own behavior
       if app.respond_to?(:deprecators)
         app.deprecators.each do |deprecator|
           current_behaviors = Array(deprecator.behavior)

--- a/lib/infield/rails.rb
+++ b/lib/infield/rails.rb
@@ -2,20 +2,24 @@
 
 module Infield
   class Railtie < Rails::Railtie
-    initializer 'infield.deprecation_warnings', after: 'active_support.deprecation_behavior' do |_app|
-      infield_lambda = lambda do |message, callstack, *args|
+    initializer 'infield.enable_report_deprecations', before: 'active_support.deprecation_behavior' do |app|
+      app.config.active_support.report_deprecations = true
+    end
+
+    initializer 'infield.deprecation_warnings', after: 'active_support.deprecation_behavior' do |app|
+      infield_logger = lambda do |message, callstack, *_args|
         Infield::DeprecationWarning.log(message, callstack: callstack, validated: true)
       end
 
       # Rails >= 7.0 makes it so that there are named deprecators that can have their own behavior
-      if Rails.application.respond_to?(:deprecators)
-        Rails.application.deprecators.each do |deprecator|
-          current    = Array(deprecator.behavior)
-          deprecator.behavior = [infield_lambda, *current].uniq
+      if app.respond_to?(:deprecators)
+        app.deprecators.each do |deprecator|
+          current_behaviors = Array(deprecator.behavior)
+          deprecator.behavior = [infield_logger, *current_behaviors].uniq
         end
       else
         current_behaviors = Array(ActiveSupport::Deprecation.behavior)
-        ActiveSupport::Deprecation.behavior = [infield_lambda, *current_behaviors].uniq
+        ActiveSupport::Deprecation.behavior = [infield_logger, *current_behaviors].uniq
       end
     end
   end

--- a/lib/infield/version.rb
+++ b/lib/infield/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Infield
-  VERSION = '0.4.0'
+  VERSION = '0.5.0'
 end


### PR DESCRIPTION
With this change, the gem should always be able to collect deprecation warnings once `Infield.run` is called, even if `app.config.active_support.report_deprecations` is set to false.